### PR TITLE
Update spatie/laravel-package-tools from ^1.13.0 to ^1.15.0

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -17,7 +17,7 @@
     ],
     "require": {
         "php": "^8.1",
-        "spatie/laravel-package-tools": "^1.13.0",
+        "spatie/laravel-package-tools": "^1.15.0",
         "illuminate/contracts": "^9.0|^10.0"
     },
     "require-dev": {


### PR DESCRIPTION
Further explanation could be found here: https://github.com/spatie/laravel-package-tools/pull/28

The update is to fix the issue of "Can't locate path"