### PR TITLE
Add backfill method

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,58 @@ Kpi::create([
 ]);
 ```
 
+For convenience, you could use the `HasKpi` trait on your model:
+
+```php
+namespace App\Models;
+
+use Finller\Kpi\HasKpi;
+
+class User extends Model
+{
+    use HasKpi;
+    
+    // ...
+}
+```
+
+If you have historical data, you could also call the `backfillKpiCount` method on your model:
+
+```php
+// Get the number of users for each day
+// from the beginning of your app
+User::backfillKpiCount();
+// Specify a interval, column, start and end dates
+User::backfillKpiCount(
+    interval: KpiInterval::Day, // default
+    column: 'created_at', // default
+    start: now()->subDay(30),
+    end: now(),
+    key: 'count' // default
+);
+// Backfill on callback
+User::backfillKpi(
+    callback: function (Builder $query) {
+        $query->whereBetween($column, [
+            $start,
+            Carbon::parse($date['created_at'])->endOfDay(),
+        ])
+            ->count();
+
+        return [
+            'key' => $key,
+            'number_value' => $count,
+            'created_at' => $date['created_at'],
+        ];
+    },
+    interval: KpiInterval::Day, // default
+    column: 'created_at', // default
+    start: now()->subDay(30),
+    end: now(),
+    key: 'count' // default
+);
+```
+
 Generally kpis are related to models, that's why we provid a trait `HasKpi` with a standardized way to name your kpi key `{namespace}:{key}`. For the User model, it would store your key in the `users` namespace like `users:{key}`.
 
 A standard way to save your kpi values would be in a command that runs every day.

--- a/README.md
+++ b/README.md
@@ -116,11 +116,7 @@ By default the placeholders will be a copy of their previous kpi.
 For convenience the `KpiBuilder` is the best option as it will give you better typed values and shares parameters between `fillGaps` and `between`.
 
 ```php
-KpiBuilder::query('users:blocked:count')
-    ->perDay()
-    ->between(now()->subWeek(), now())
-    ->fillGaps()
-    ->get();
+use Finller\Kpi\Enums\KpiInterval;
 
 Kpi::query()
     ->where('key', 'users:blocked:count')
@@ -130,9 +126,15 @@ Kpi::query()
     ->fillGaps( // optional parameters
         start: now()->subWeek(),
         end: now(),
-        interval: 'day',
+        interval: KpiInterval::Day,
         default: ['number_value' => 0]
     );
+    
+KpiBuilder::query('users:blocked:count')
+    ->perDay()
+    ->between(now()->subWeek(), now())
+    ->fillGaps()
+    ->get();
 
 Kpi::query()
     ->where('key', 'users:blocked:count')

--- a/composer.json
+++ b/composer.json
@@ -1,22 +1,17 @@
 {
-    "name": "imseaworld/laravel-kpi",
-    "description": "Fork of finller's laravel-kpi package",
+    "name": "finller/laravel-kpi",
+    "description": "This is my package laravel-kpi",
     "keywords": [
         "finller",
         "laravel",
         "laravel-kpi"
     ],
-    "homepage": "https://github.com/imseaworld/laravel-kpi",
+    "homepage": "https://github.com/finller/laravel-kpi",
     "license": "MIT",
     "authors": [
         {
             "name": "Quentin Gabriele",
             "email": "quentin.gabriele@gmail.com",
-            "role": "Developer"
-        },
-        {
-            "name": "Robert Klitsch",
-            "homepage": "https://github.com/ImSeaWorld",
             "role": "Developer"
         }
     ],

--- a/composer.json
+++ b/composer.json
@@ -1,17 +1,22 @@
 {
-    "name": "finller/laravel-kpi",
-    "description": "This is my package laravel-kpi",
+    "name": "imseaworld/laravel-kpi",
+    "description": "Fork of finller's laravel-kpi package",
     "keywords": [
         "finller",
         "laravel",
         "laravel-kpi"
     ],
-    "homepage": "https://github.com/finller/laravel-kpi",
+    "homepage": "https://github.com/imseaworld/laravel-kpi",
     "license": "MIT",
     "authors": [
         {
             "name": "Quentin Gabriele",
             "email": "quentin.gabriele@gmail.com",
+            "role": "Developer"
+        },
+        {
+            "name": "Robert Klitsch",
+            "homepage": "https://github.com/ImSeaWorld",
             "role": "Developer"
         }
     ],

--- a/composer.json
+++ b/composer.json
@@ -17,7 +17,7 @@
     ],
     "require": {
         "php": "^8.1",
-        "spatie/laravel-package-tools": "^1.13.0",
+        "spatie/laravel-package-tools": "^1.15.0",
         "illuminate/contracts": "^9.0|^10.0"
     },
     "require-dev": {

--- a/src/HasKpi.php
+++ b/src/HasKpi.php
@@ -2,18 +2,8 @@
 
 namespace Finller\Kpi;
 
-use Carbon\{
-    Carbon,
-    Exceptions\InvalidFormatException
-};
-use Illuminate\{
-    Support\Str,
-    Contracts\Container\BindingResolutionException
-};
-use Psr\Container\{
-    NotFoundExceptionInterface,
-    ContainerExceptionInterface
-};
+use Carbon\Carbon;
+use Illuminate\Support\Str;
 use Finller\Kpi\Enums\KpiInterval;
 
 trait HasKpi

--- a/src/HasKpi.php
+++ b/src/HasKpi.php
@@ -2,7 +2,19 @@
 
 namespace Finller\Kpi;
 
-use Illuminate\Support\Str;
+use Carbon\{
+    Carbon,
+    Exceptions\InvalidFormatException
+};
+use Illuminate\{
+    Support\Str,
+    Contracts\Container\BindingResolutionException
+};
+use Psr\Container\{
+    NotFoundExceptionInterface,
+    ContainerExceptionInterface
+};
+use Finller\Kpi\Enums\KpiInterval;
 
 trait HasKpi
 {
@@ -23,8 +35,86 @@ trait HasKpi
         $model = config('kpi.kpi_model');
 
         return $model::create([
-            'key' => static::getKpiNamespace().':count',
+            'key' => static::getKpiNamespace() . ':count',
             'number_value' => static::count(),
         ]);
+    }
+
+    public static function backfillKpi(
+        callable $callback,
+        ?KpiInterval $interval = KpiInterval::Day,
+        ?string $column = 'created_at',
+        ?Carbon $start = null,
+        ?Carbon $end = null,
+        ?string $key = 'count',
+    ): array {
+        $kpiModel = config('kpi.kpi_model');
+        /** @var ?Carbon */
+        $start = $start ?? Carbon::parse(static::min($column));
+        /** @var ?Carbon */
+        $end = $end ?? Carbon::parse(static::max($column));
+        /** @var string */
+        $key = static::getKpiNamespace() . ':' . $key;
+        /** @var Carbon[] */
+        $fillDates = $kpiModel::query()
+            ->where('key', $key)
+            ->perInterval($interval)
+            ->between($start, $end)
+            ->get()
+            ->fillGaps($start, $end, $interval, [
+                'key' => $key,
+                'number_value' => 0
+            ])
+            ->toArray();
+
+        foreach ($fillDates as $k => $date) {
+            if (isset($date['id'])) continue;
+
+            $kpi = new $kpiModel();
+
+            $kpi->fill(call_user_func(
+                $callback,
+                static::query(),
+                $start,
+                $end,
+                $key,
+                $date
+            ));
+
+            $kpi->save();
+
+            $fillDates[$k] = $kpi->toArray();
+        }
+        /** @return array */
+        return $fillDates;
+    }
+
+    public static function backfillKpiCount(
+        ?KpiInterval $interval = KpiInterval::Day,
+        ?string $column = 'created_at',
+        ?Carbon $start = null,
+        ?Carbon $end = null,
+        ?string $key = 'count'
+    ): array {
+        return static::backfillKpi(
+            function ($model, $start, $end, $key, $date) use ($column) {
+                $count = $model->whereBetween($column, [
+                    $start,
+                    Carbon::parse($date['created_at'])->endOfDay(),
+                ])
+                    ->count();
+
+                return [
+                    'key' => $key,
+                    'number_value' => $count,
+                    'created_at' => $date['created_at'],
+                ];
+            },
+            $interval,
+            $column,
+            $start,
+            $end,
+            $key,
+        );
     }
 }

--- a/src/KpiServiceProvider.php
+++ b/src/KpiServiceProvider.php
@@ -17,6 +17,6 @@ class KpiServiceProvider extends PackageServiceProvider
         $package
             ->name('laravel-kpi')
             ->hasConfigFile()
-            ->hasMigration('create_kpi_table');
+            ->hasMigration('create_kpis_table');
     }
 }

--- a/src/Support/KpiCollection.php
+++ b/src/Support/KpiCollection.php
@@ -2,22 +2,30 @@
 
 namespace Finller\Kpi\Support;
 
-use Carbon\Carbon;
 use Exception;
-use Finller\Kpi\Enums\KpiInterval;
-use Finller\Kpi\Kpi;
-use Illuminate\Database\Eloquent\Collection;
-use Illuminate\Support\Arr;
+use Carbon\Carbon;
+use Finller\Kpi\{
+    Kpi,
+    Enums\KpiInterval
+};
+use Illuminate\{
+    Support\Arr,
+    Database\Eloquent\Collection
+};
 
 class KpiCollection extends Collection
 {
-    public function fillGaps(?Carbon $start = null, ?Carbon $end = null, ?KpiInterval $interval = null, ?array $default = null): static
-    {
+    public function fillGaps(
+        ?Carbon $start = null,
+        ?Carbon $end = null,
+        ?KpiInterval $interval = null,
+        ?array $default = null
+    ): static {
         $model = config('kpi.kpi_model');
 
         $collection = new static($this->sortBy('created_at')->all());  // @phpstan-ignore-line
 
-        if (! $interval && ($this->count() < 2)) {
+        if (!$interval && ($this->count() < 2)) {
             throw new Exception("interval between items can't be guessed from a single element, provid the interval parameter.");
         }
 
@@ -32,7 +40,7 @@ class KpiCollection extends Collection
 
         $interval = $interval ?? $this->guessInterval();
 
-        if (! $start || ! $end || ! $interval) {
+        if (!$start || !$end || !$interval) {
             return $collection;
         }
 
@@ -44,7 +52,7 @@ class KpiCollection extends Collection
             /** @var ?Kpi $item */
             $item = $collection->get($indexItem);
 
-            if (! $item?->created_at->isSameAs($dateFormatComparator, $date)) {
+            if (!$item?->created_at->isSameAs($dateFormatComparator, $date)) {
                 $placeholderItem = $collection->get($indexItem - 1) ?? $item ?? $collection->last();
 
                 $placeholder = new $model();


### PR DESCRIPTION
### Added
 - `backfillKpi`
 - `backfillKpiCount`

### Fixed
 - Migration stub file was misspelled: `create_kpi_table` -> `create_kpis_table`

### Description
When first instantiating KPIs in an already existing project. It's very helpful to gather historical KPI information.

### Usage:
```php
use Carbon\Carbon;
use App\Models\Task; // Add: `use HasKpi`
use Finller\Kpi\Enums\KpiInterval;

Task::backfillKpiCount(
  interval: KpiInterval::Day,
  column: 'created_at',
  start: null,
  end: Carbon::now(),
  key: 'count'
);

Task::backfillKpi(
  function ($model, $start, $end, $key, $date) use ($column) {
    $count = $model->whereBetween($column, [
      $start,
      Carbon::parse($date['created_at'])->endOfDay(),
    ])
      ->count();
    
    return [
      'key' => $key,
      'number_value' => $count,
      'created_at' => $date['created_at']
    ];
  },
  interval: KpiInterval::Day,
  column: 'created_at',
  start: null,
  end: Carbon::now(),
  key: 'count'
);

// These will return an array from Kpi collection
[
  [
    "id" => 1,
    "key" => "tasks:count",
    "number_value" => 1.0,
    "string_value" => null,
    "money_value" => 0,
    "money_currency" => null,
    "json_value" => null,
    "description" => null,
    "metadata" => null,
    "created_at" => "2022-01-13T14:21:28.000000Z",
    "updated_at" => "2023-07-21T22:37:08.000000Z",
  ],
  // ...
]
```
